### PR TITLE
typo, showstopper preventing openid from working, error when realm is mismatched.

### DIFF
--- a/velruse/app.py
+++ b/velruse/app.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 @view_config(context='velruse.api.AuthenticationComplete')
 def auth_complete_view(context, request):
-    end_point = request.settings.get('velruse.end_point')
+    end_point = request.registry.settings.get('velruse.end_point')
     token = generate_token()
     storage = request.registry.velruse_store
     result_data = {
@@ -30,7 +30,7 @@ def auth_complete_view(context, request):
 
 @view_config(context='velruse.exceptions.AuthenticationDenied')
 def auth_denied_view(context, request):
-    end_point = request.settings.get('velruse.end_point')
+    end_point = request.registry.settings.get('velruse.end_point')
     token = generate_token()
     storage = request.registry.velruse_store
     error_dict = {
@@ -53,7 +53,7 @@ def default_setup(config):
     from pyramid.session import UnencryptedCookieSessionFactoryConfig
 
     log.info('Using an unencrypted cookie-based session. This can be '
-             'changed by pointing the "velruse.setup" setting at a different'
+             'changed by pointing the "velruse.setup" setting at a different '
              'function for configuring the session factory.')
 
     settings = config.registry.settings

--- a/velruse/providers/openidconsumer.py
+++ b/velruse/providers/openidconsumer.py
@@ -325,9 +325,10 @@ class OpenIDConsumer(object):
             log.debug('Handling processing of response from server')
 
         openid_session = request.session.get('openid_session', None)
-        del request.session['openid_session']
         if not openid_session:
             raise ThirdPartyFailure("No OpenID Session has begun.")
+        else:
+            del request.session['openid_session']
 
         # Setup the consumer and parse the information coming back
         oidconsumer = consumer.Consumer(openid_session, self.openid_store)


### PR DESCRIPTION
typo in log message (missing trailing space on continued line)
request.settings -> request.registry.settings
openid consumer realm mismatch results in None, del of session results in error
