### PR TITLE
removed velruse.facebook.api_key

### DIFF
--- a/velruse/app.py
+++ b/velruse/app.py
@@ -129,7 +129,6 @@ def make_velruse_app(global_conf, **settings):
             velruse.providers.facebook
             velruse.providers.twitter
 
-        velruse.facebook.api_key = eb7cf817bab6e28d3b941811cf1b014e
         velruse.facebook.app_secret = KMfXjzsA2qVUcnnRn3vpnwWZ2pwPRFZdb
         velruse.facebook.app_id = ULZ6PkJbsqw2GxZWCIbOEBZdkrb9XwgXNjRy
         velruse.twitter.consumer_key = ULZ6PkJbsqw2GxZWCIbOEBZdkrb9XwgXNjRy


### PR DESCRIPTION
Not referenced in the code, Facebook removed API Key in early 2010. App ID is now the identifier that they use, API Key is considered the same for legacy purposes.

velruse.provider.facebook doesn't refer to api_key. Removed from app.py to reduce confusion. They both should have the same value if stated separately, example in app.py had two different values.
