### PR TITLE
hide/autosubmit on OpenID continue form

### DIFF
--- a/velruse/utils.py
+++ b/velruse/utils.py
@@ -14,10 +14,23 @@ def flat_url(url, **kw):
 def redirect_form(end_point, token):
     """Generate a redirect form for POSTing"""
     return """
+<html>
+<head>
+  <title>OpenID transaction in progress</title>
+</head>
+<body onload="document.forms[0].submit();">
 <form action="%s" method="post" accept-charset="UTF-8"
  enctype="application/x-www-form-urlencoded">
 <input type="hidden" name="token" value="%s" />
 <input type="submit" value="Continue"/></form>
+<script>
+var elements = document.forms[0].elements;
+for (var i = 0; i < elements.length; i++) {
+  elements[i].style.display = "none";
+}
+</script>
+</body>
+</html>
 """ % (end_point, token)
 
 


### PR DESCRIPTION
Somehow, a development commit was combined in the last pull request.

This pull request contains just the HTML change to make Facebook/Twitter authentications automatically submit without showing the 'Continue' form button.
