### PR TITLE
Fixed store backends' methods, auth_denied_view() method and auth URLs in docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.vim
 config.yaml
 .coverage
+.project
+.pydevproject
 test.ini
 data
 build

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -38,7 +38,7 @@ Each :term:`auth provider` must be a callable. It will be called with a
 :class:`webob.Request` instance and must respond with a
 :class:`webob.Response` instance.
 
-The Auth Provider is expected to respond to a POST to `/auth`, and then
+The Auth Provider is expected to respond to a POST to `/login`, and then
 proceed with the necessary calls and/or redirects necessary to complete
 the authentication. The normalized user data should then be written to the
 store, and a token returned to the user.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -58,7 +58,7 @@ Complete Example:
 
 .. code-block:: html
 
-    <form action="/velruse/facebook/auth" method="post">
+    <form action="/velruse/facebook/login" method="post">
     <input type="hidden" name="scope" value="publish_stream,create_event" />
     <input type="submit" value="Login with Facebook" />
     </form>
@@ -104,7 +104,7 @@ Complete Example:
 
 .. code-block:: html
 
-    <form action="/velruse/openid/auth" method="post">
+    <form action="/velruse/openid/login" method="post">
     <input type="text" name="openid_identifier" />
     <input type="submit" value="Login with OpenID" />
     </form>
@@ -177,7 +177,7 @@ Complete Example:
 
 .. code-block:: html
 
-    <form action="/velruse/google/auth" method="post">
+    <form action="/velruse/google/login" method="post">
     <input type="hidden" name="popup_mode" value="popup" />
     <input type="hidden" name="oauth_scope" value="http://www.google.com/m8/feeds/" />
     <input type="submit" value="Login with Google" />
@@ -232,7 +232,7 @@ Complete Example:
 
 .. code-block:: html
 
-    <form action="/velruse/yahoo/auth" method="post">
+    <form action="/velruse/yahoo/login" method="post">
     <input type="hidden" name="oauth" value="true" />
     <input type="submit" value="Login with Yahoo" />
     </form>
@@ -266,7 +266,7 @@ Complete Example:
 
 .. code-block:: html
 
-    <form action="/velruse/twitter/auth" method="post">
+    <form action="/velruse/twitter/login" method="post">
     <input type="submit" value="Login with Twitter" />
     </form>
 
@@ -348,6 +348,6 @@ Complete Example:
 
 .. code-block:: html
     
-    <form action="/velruse/live/auth" method="post">
+    <form action="/velruse/live/login" method="post">
     <input type="submit" value="Login with Windows Live" />
     </form>

--- a/velruse/app.py
+++ b/velruse/app.py
@@ -37,8 +37,8 @@ def auth_denied_view(context, request):
     token = generate_token()
     storage = request.registry.velruse_store
     error_dict = {
-        'code': context.code,
-        'description': context.description,
+        'code': getattr(context, 'code', None), 
+        'description': context.message, 
     }
     storage.store(token, error_dict, expires=300)
     form = redirect_form(endpoint, token)

--- a/velruse/store/memcached_store.py
+++ b/velruse/store/memcached_store.py
@@ -12,9 +12,9 @@ except ImportError:
 #from redis.exceptions import RedisError  #unused afaik -- bayle
 
 from pyramid.exceptions import ConfigurationError
+from pyramid.decorator import reify
 
 from velruse.store.interface import UserStore
-from velruse.utils import cached_property
 from velruse.utils import splitlines
 
 
@@ -37,7 +37,7 @@ class MemcachedStore(UserStore):
         self.key_prefix = key_prefix
         self.servers = servers or ['localhost:11211']
 
-    @cached_property
+    @reify
     def _conn(self):
         """The Memcached connection, cached for this call"""
         return memcache.Client(self.servers)

--- a/velruse/store/mongodb_store.py
+++ b/velruse/store/mongodb_store.py
@@ -11,10 +11,9 @@ from pymongo.binary import Binary
 from pymongo.errors import OperationFailure
 
 from pyramid.exceptions import ConfigurationError
+from pyramid.decorator import reify
 
 from velruse.store.interface import UserStore
-from velruse.utils import cached_property
-
 
 def includeme(config):
     settings = config.registry.settings
@@ -41,7 +40,7 @@ class MongoDBStore(UserStore):
         self.db = db
         self.collection = collection
 
-    @cached_property  # Fix this later -htormey
+    @reify
     def _conn(self):
         """The MongoDB connection, cached for this call"""
         try:

--- a/velruse/store/redis_store.py
+++ b/velruse/store/redis_store.py
@@ -6,10 +6,9 @@ except ImportError:
 
 import redis
 from redis.exceptions import RedisError
+from pyramid.decorator import reify
 
 from velruse.store.interface import UserStore
-from velruse.utils import cached_property
-
 
 def includeme(config):
     settings = config.registry.settings
@@ -32,7 +31,7 @@ class RedisStore(UserStore):
         self.db = db
         self.key_prefix = key_prefix
 
-    @cached_property
+    @reify
     def _conn(self):
         """The Redis connection, cached for this call"""
         return redis.Redis(host=self.host, port=self.port, db=self.db)


### PR DESCRIPTION
- Fixed docs: auth URLs of auth providers are changed to /login now.
- Replaced cached_property (which was missing) to pyramid.decorator.reify in memcached, Redis and MongoDB store methods.
- Fixed velruse.app.auth_denied_view() to store valid error info out of context which is an exception (VelruseException should propably get status code from response).
