### PR TITLE
Add ability to use specific apps domain with the Google provider.

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -144,6 +144,9 @@ velruse.google.consumer_key
 velruse.google.consumer_secret
     Consumer secret as specified
 velruse.google.oauth_scope
+velruse.google.apps_domain
+    Google apps domain, e.g. 'yourdomain.com'. Setting this will cause the use
+    of a domain specific endpoint.
 
 .. warning::
 

--- a/velruse/providers/google.py
+++ b/velruse/providers/google.py
@@ -35,7 +35,8 @@ def includeme(config):
         process_url='google_process',
         oauth_key=settings.get('velruse.google.consumer_key'),
         oauth_secret=settings.get('velruse.google.consumer_secret'),
-        request_attributes=settings.get('request_attributes')
+        request_attributes=settings.get('request_attributes'),
+        apps_domain=settings.get('velruse.google.apps_domain')
     )
     config.add_route("google_login", "/google/login")
     config.add_route("google_process", "/google/process",
@@ -46,7 +47,8 @@ def includeme(config):
 
 class GoogleConsumer(OpenIDConsumer):
     def __init__(self, oauth_key=None, oauth_secret=None,
-                 request_attributes=None, *args, **kwargs):
+                 request_attributes=None, apps_domain=None, *args,
+                 **kwargs):
         """Handle Google Auth
 
         This also handles making an OAuth request during the OpenID
@@ -62,10 +64,16 @@ class GoogleConsumer(OpenIDConsumer):
         else:
             self.request_attributes = ['country', 'email', 'first_name',
                                        'last_name', 'language']
+        if apps_domain is None:
+            self.directed_endpoint = "https://www.google.com/accounts/o8/id"
+        else:
+            self.directed_endpoint = (
+                    "https://www.google.com/accounts/o8/site-xrds?hd=%s" %
+                    apps_domain)
 
     def _lookup_identifier(self, request, identifier):
         """Return the Google OpenID directed endpoint"""
-        return "https://www.google.com/accounts/o8/id"
+        return self.directed_endpoint
 
     def _update_authrequest(self, request, authrequest):
         """Update the authrequest with Attribute Exchange and optionally OAuth


### PR DESCRIPTION
This will allow the use of a domain specific endpoint when using the Google
provider.

The use of a domain specific endpoint will make it more convenient to login with an account hosted in a Google Apps hosted domain. For example, if I wanted to used the domain specific endpoint for example.com, the page that the user is redirected to to login with Google will only allow logins from the example.com domain. The user also wouldn't have to type in the @example.com part of their username.
