### PR TITLE
Change the default value of the facebook provider "scope" parameter from None to empty string

### DIFF
--- a/velruse/providers/facebook.py
+++ b/velruse/providers/facebook.py
@@ -44,7 +44,7 @@ def add_facebook_login_from_settings(config, prefix='velruse.facebook.'):
 def add_facebook_login(config,
                        consumer_key,
                        consumer_secret,
-                       scope=None,
+                       scope='',
                        login_path='/login/facebook',
                        callback_path='/login/facebook/callback',
                        name='facebook'):


### PR DESCRIPTION
The Facebook Provider "scope" configuration should default to empty string instead of None (which ends up being converted to the string 'None').

Previously, omitting  "facebook.scope" from the .ini file would result in an error upon login attempt: "Invalid parameter Scope' ... "'None' is not a valid value..."
