### PR TITLE
Fix CSRF vulnerability

### DIFF
--- a/velruse/providers/facebook.py
+++ b/velruse/providers/facebook.py
@@ -89,11 +89,16 @@ class FacebookProvider(object):
 
     def callback(self, request):
         """Process the facebook redirect"""
-        if request.GET.get('state') != request.session.get('state'):
+        sess_state = request.session.get('state')
+        req_state = request.GET.get('state')
+        if not sess_state or sess_state != req_state:
             raise CSRFError(
-                'CSRF Validation check failed. Request state %s is not '
-                'the same as session state %s' % (
-                    request.GET.get('state'), request.session.get('state')))
+                'CSRF Validation check failed. Request state {req_state} is not '
+                'the same as session state {sess_state}'.format(
+                    req_state=req_state,
+                    sess_state=sess_state
+                )
+            )
         code = request.GET.get('code')
         if not code:
             reason = request.GET.get('error_reason', 'No reason provided.')

--- a/velruse/providers/github.py
+++ b/velruse/providers/github.py
@@ -105,11 +105,16 @@ class GithubProvider(object):
 
     def callback(self, request):
         """Process the github redirect"""
-        if request.GET.get('state') != request.session.get('state'):
+        sess_state = request.session.get('state')
+        req_state = request.GET.get('state')
+        if not sess_state or sess_state != req_state:
             raise CSRFError(
-                'CSRF Validation check failed. Request state %s is not '
-                'the same as session state %s' % (
-                    request.GET.get('state'), request.session.get('state')))
+                'CSRF Validation check failed. Request state {req_state} is not '
+                'the same as session state {sess_state}'.format(
+                    req_state=req_state,
+                    sess_state=sess_state
+                )
+            )
         code = request.GET.get('code')
         if not code:
             reason = request.GET.get('error', 'No reason provided.')

--- a/velruse/providers/vk.py
+++ b/velruse/providers/vk.py
@@ -107,12 +107,14 @@ class VKProvider(object):
 
     def callback(self, request):
         """Process the VK redirect"""
-        if request.GET.get('state') != request.session.get('state'):
+        sess_state = request.session.get('state')
+        req_state = request.GET.get('state')
+        if not sess_state or sess_state != req_state:
             raise CSRFError(
                 'CSRF Validation check failed. Request state {req_state} is not '
                 'the same as session state {sess_state}'.format(
-                    req_state=request.GET.get('state'),
-                    sess_state=request.session.get('state')
+                    req_state=req_state,
+                    sess_state=sess_state
                 )
             )
         code = request.GET.get('code')

--- a/velruse/providers/weibo.py
+++ b/velruse/providers/weibo.py
@@ -81,11 +81,16 @@ class WeiboProvider(object):
 
     def callback(self, request):
         """Process the weibo redirect"""
-        if request.GET.get('state') != request.session.get('state'):
-            raise CSRFError("CSRF Validation check failed. Request state %s is "
-                            "not the same as session state %s" % (
-                            request.GET.get('state'), request.session.get('state')
-                            ))
+        sess_state = request.session.get('state')
+        req_state = request.GET.get('state')
+        if not sess_state or sess_state != req_state:
+            raise CSRFError(
+                'CSRF Validation check failed. Request state {req_state} is not '
+                'the same as session state {sess_state}'.format(
+                    req_state=req_state,
+                    sess_state=sess_state
+                )
+            )
         code = request.GET.get('code')
         if not code:
             reason = request.GET.get('error_reason', 'No reason provided.')

--- a/velruse/providers/yandex.py
+++ b/velruse/providers/yandex.py
@@ -99,12 +99,14 @@ class YandexProvider(object):
 
     def callback(self, request):
         """Process the Yandex redirect"""
-        if request.GET.get('state') != request.session.get('state'):
+        sess_state = request.session.get('state')
+        req_state = request.GET.get('state')
+        if not sess_state or sess_state != req_state:
             raise CSRFError(
                 'CSRF Validation check failed. Request state {req_state} is not '
                 'the same as session state {sess_state}'.format(
-                    req_state=request.GET.get('state'),
-                    sess_state=request.session.get('state')
+                    req_state=req_state,
+                    sess_state=sess_state
                 )
             )
         code = request.GET.get('code')


### PR DESCRIPTION
Currently, OAuth providers are still vulnerable to CSRF attacks.

``` python
if request.GET.get('state') != request.session.get('state'):
    raise CSRFError(
        'CSRF Validation check failed. Request state %s is not '
        'the same as session state %s' % (
            request.GET.get('state'), request.session.get('state')))
```

This code is vulnerable, because None equals None.

Related article - http://homakov.blogspot.com/2012/07/saferweb-most-common-oauth2.html
