### PR TITLE
Add a MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.rst
+include LICENSE.txt
+include TODO.rst
+include CHANGES.rst
+
+graft docs
+graft examples
+gract tests


### PR DESCRIPTION
With this, supporting folders and documents will get distributed with the
velruse tarball on pypi.  This is super useful for Linux distributions that
want to include as much upstream metadata as possible when re-packaging.
