### PR TITLE
Add support for "display" parameter with Facebook

### DIFF
--- a/docs/providers/facebook.rst
+++ b/docs/providers/facebook.rst
@@ -55,6 +55,12 @@ Complete Example:
         <input type="submit" value="Login with Facebook" />
     </form>
 
+Facebook also accepts a display argument, which will indicate the UI for Facebook
+to use. For more information, see `OAuth Dialog <https://developers.facebook.com/docs/reference/dialogs/oauth/`_. For instance, if you would like to use the "popup" interface:
+
+.. code-block:: html
+
+    <input type="hidden" name="display" value="popup" />
 
 Pyramid API
 -----------

--- a/velruse/providers/facebook.py
+++ b/velruse/providers/facebook.py
@@ -71,6 +71,7 @@ class FacebookProvider(object):
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
         self.scope = scope
+        self.display = 'page'
 
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
@@ -78,10 +79,12 @@ class FacebookProvider(object):
     def login(self, request):
         """Initiate a facebook login"""
         scope = request.POST.get('scope', self.scope)
+        display = request.POST.get('display', self.display)
         request.session['state'] = state = uuid.uuid4().hex
         fb_url = flat_url(
             'https://www.facebook.com/dialog/oauth/',
             scope=scope,
+            display=display,
             client_id=self.consumer_key,
             redirect_uri=request.route_url(self.callback_route),
             state=state)


### PR DESCRIPTION
Allows an additional POST parameter for the Facebook provider to specify the 'display' (e.g. "popup"). Documentation update included.
