### PR TITLE
Patch proposal to fix #113

### DIFF
--- a/velruse/providers/google_oauth2.py
+++ b/velruse/providers/google_oauth2.py
@@ -167,7 +167,10 @@ class GoogleOAuth2Provider(object):
                 'username': data['email'],
                 'userid': data['id']
             }]
-            profile['displayName'] = data['name']
+            if 'name' in data:
+                profile['displayName'] = data['name']
+            else:
+                profile['displayName'] = data['email']
             profile['preferredUsername'] = data['email']
             profile['verifiedEmail'] = data['email']
             profile['emails'] = [{'value': data['email']}]


### PR DESCRIPTION
Hi,
the following modification fix the issue I created (#113) that raise an exception if name is not present for Google oauth2 authentification.

I propose to set email in displayname if name is not present.
