### PR TITLE
Allow openid to run in stateless mode

### DIFF
--- a/docs/providers/openid.rst
+++ b/docs/providers/openid.rst
@@ -22,7 +22,10 @@ Settings
 ``realm``
     Domain for your website, e.g. ``http://yourdomain.com/``
 ``store``
-    A class from which the OpenID store will be instantiated.
+    An instance of an OpenID store. (default
+    :class:`openid.stores.memstore.MemoryStore`). You may also use :const:`velruse.openid.STATELESS` to
+    run openid in `stateless
+    mode <http://openid.net/specs/openid-authentication-2_0.html#check_auth>`_.
 
 .. note::
 

--- a/velruse/providers/openid.py
+++ b/velruse/providers/openid.py
@@ -21,7 +21,7 @@ from ..exceptions import (
     ThirdPartyFailure,
 )
 
-NO_ARG = object()
+STATELESS = object()
 
 log = __import__('logging').getLogger(__name__)
 
@@ -92,8 +92,8 @@ def add_openid_login(config,
     Add a OpenID login provider to the application.
 
     `storage` should be an object conforming to the
-    `openid.store.interface.OpenIDStore` protocol. This will default
-    to `openid.store.memstore.MemoryStore`.
+    `openid.store.interface.OpenIDStore` protocol or :const:`.STATELESS`.
+    This will default to `openid.store.memstore.MemoryStore`.
     """
     provider = OpenIDConsumer(name, realm=realm, storage=storage)
 
@@ -118,7 +118,7 @@ class OpenIDConsumer(object):
                  name,
                  _type=None,
                  realm=None,
-                 storage=NO_ARG,
+                 storage=None,
                  context=OpenIDAuthenticationComplete):
         self.openid_store = storage
         self.name = name
@@ -129,12 +129,14 @@ class OpenIDConsumer(object):
         self.login_route = 'velruse.%s-url' % name
         self.callback_route = 'velruse.%s-callback' % name
 
-    _openid_store = NO_ARG
+    _openid_store = None
 
     def _get_openid_store(self):
-        if self._openid_store is NO_ARG:
+        if self._openid_store is None:
             from openid.store.memstore import MemoryStore
             self._openid_store = MemoryStore()
+        elif self._openid_store is STATELESS:
+            return None
         return self._openid_store
 
     def _set_openid_store(self, val):

--- a/velruse/providers/openid.py
+++ b/velruse/providers/openid.py
@@ -21,6 +21,7 @@ from ..exceptions import (
     ThirdPartyFailure,
 )
 
+NO_ARG = object()
 
 log = __import__('logging').getLogger(__name__)
 
@@ -117,7 +118,7 @@ class OpenIDConsumer(object):
                  name,
                  _type=None,
                  realm=None,
-                 storage=None,
+                 storage=NO_ARG,
                  context=OpenIDAuthenticationComplete):
         self.openid_store = storage
         self.name = name
@@ -128,10 +129,10 @@ class OpenIDConsumer(object):
         self.login_route = 'velruse.%s-url' % name
         self.callback_route = 'velruse.%s-callback' % name
 
-    _openid_store = None
+    _openid_store = NO_ARG
 
     def _get_openid_store(self):
-        if self._openid_store is None:
+        if self._openid_store is NO_ARG:
             from openid.store.memstore import MemoryStore
             self._openid_store = MemoryStore()
         return self._openid_store


### PR DESCRIPTION
If we pass 'storage=None' to an openid provider, it should run the
python openid consumer in stateless mode.

With the default options I was unable to run multiple wsgi workers and do openid auth because it was using a MemoryStore that was not shared among the workers. In order to run in stateless mode, you have to pass 'store=None' to the openid consumer, but the current OpenID provider was preventing that.

MemoryStore is still the default value for storage, but now if you explicitly pass 'storage=None' it will run in stateless mode.
