### PR TITLE
Fire an event before the authentication starts

### DIFF
--- a/velruse/events.py
+++ b/velruse/events.py
@@ -1,0 +1,19 @@
+import functools
+
+def with_events(event=None):
+    """Decorator to create event book ends on a method."""
+    def decorator(method):
+        @functools.wraps(method)
+        def new_method(obj, request):
+            request.registry.notify(event(request, obj.type))
+            response = method(obj, request)
+            return response
+        return new_method
+    return decorator
+
+
+class AuthenticationStarted(object):
+    def __init__(self, request, provider):
+        self.request = request
+        self.provider = provider
+

--- a/velruse/providers/bitbucket.py
+++ b/velruse/providers/bitbucket.py
@@ -14,6 +14,7 @@ from ..api import (
     register_provider,
 )
 from ..compat import parse_qsl
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -78,6 +79,7 @@ class BitbucketProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a bitbucket login"""
         # grab the initial request token

--- a/velruse/providers/douban.py
+++ b/velruse/providers/douban.py
@@ -9,6 +9,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -69,6 +70,7 @@ class DoubanProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a douban login"""
         scope = request.POST.get('scope', self.scope)

--- a/velruse/providers/facebook.py
+++ b/velruse/providers/facebook.py
@@ -12,6 +12,7 @@ from ..api import (
     register_provider,
 )
 from ..compat import parse_qsl
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
@@ -74,6 +75,7 @@ class FacebookProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a facebook login"""
         scope = request.POST.get('scope', self.scope)

--- a/velruse/providers/github.py
+++ b/velruse/providers/github.py
@@ -12,6 +12,7 @@ from ..api import (
     register_provider,
 )
 from ..compat import parse_qsl
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
@@ -90,6 +91,7 @@ class GithubProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a github login"""
         scope = request.POST.get('scope', self.scope)

--- a/velruse/providers/google_oauth2.py
+++ b/velruse/providers/google_oauth2.py
@@ -10,6 +10,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
@@ -99,6 +100,7 @@ class GoogleOAuth2Provider(object):
         if not self.scope:
             self.scope = ' '.join((self.profile_scope, self.email_scope))
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a google login"""
         scope = ' '.join(request.POST.getall('scope')) or self.scope

--- a/velruse/providers/lastfm.py
+++ b/velruse/providers/lastfm.py
@@ -11,6 +11,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -70,6 +71,7 @@ class LastfmProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a LastFM login"""
         fb_url = flat_url('https://www.last.fm/api/auth/',

--- a/velruse/providers/linkedin.py
+++ b/velruse/providers/linkedin.py
@@ -11,6 +11,7 @@ from ..api import (
     register_provider,
 )
 from ..compat import parse_qsl
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -73,6 +74,7 @@ class LinkedInProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a LinkedIn login"""
         # grab the initial request token

--- a/velruse/providers/live.py
+++ b/velruse/providers/live.py
@@ -11,6 +11,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -71,6 +72,7 @@ class LiveProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a Live login"""
         scope = request.POST.get('scope', self.scope or

--- a/velruse/providers/mailru.py
+++ b/velruse/providers/mailru.py
@@ -16,6 +16,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError, ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -98,6 +99,7 @@ class MailRuProvider(object):
         self.login_route = 'velruse.{name}-login'.format(name=name)
         self.callback_route = 'velruse.{name}-callback'.format(name=name)
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a MailRu login"""
         request.session['state'] = state = uuid.uuid4().hex

--- a/velruse/providers/openid.py
+++ b/velruse/providers/openid.py
@@ -16,6 +16,10 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import (
+    AuthenticationStarted,
+    with_events
+)
 from ..exceptions import (
     MissingParameter,
     ThirdPartyFailure,
@@ -167,6 +171,7 @@ class OpenIDConsumer(object):
 
         """
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         log.debug('Handling OpenID login')
 

--- a/velruse/providers/qq.py
+++ b/velruse/providers/qq.py
@@ -12,6 +12,7 @@ from ..api import (
     register_provider,
 )
 from ..compat import parse_qsl
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -72,6 +73,7 @@ class QQProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a qq login"""
         scope = request.POST.get('scope', self.scope)

--- a/velruse/providers/renren.py
+++ b/velruse/providers/renren.py
@@ -9,6 +9,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -69,6 +70,7 @@ class RenrenProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a renren login"""
         scope = request.POST.get('scope', self.scope)

--- a/velruse/providers/taobao.py
+++ b/velruse/providers/taobao.py
@@ -12,6 +12,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -69,6 +70,7 @@ class TaobaoProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a taobao login"""
         gh_url = flat_url('https://oauth.taobao.com/authorize',

--- a/velruse/providers/twitter.py
+++ b/velruse/providers/twitter.py
@@ -12,6 +12,7 @@ from ..api import (
     register_provider,
 )
 from ..compat import parse_qsl
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -75,6 +76,7 @@ class TwitterProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a Twitter login"""
         # grab the initial request token

--- a/velruse/providers/vk.py
+++ b/velruse/providers/vk.py
@@ -16,6 +16,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError, ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -92,6 +93,7 @@ class VKProvider(object):
         self.login_route = 'velruse.{name}-login'.format(name=name)
         self.callback_route = 'velruse.{name}-callback'.format(name=name)
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a VK login"""
         request.session['state'] = state = uuid.uuid4().hex

--- a/velruse/providers/weibo.py
+++ b/velruse/providers/weibo.py
@@ -12,6 +12,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError
 from ..exceptions import ThirdPartyFailure
 from ..settings import ProviderSettings
@@ -73,6 +74,7 @@ class WeiboProvider(object):
         self.login_route = 'velruse.%s-login' % name
         self.callback_route = 'velruse.%s-callback' % name
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a weibo login"""
         scope = request.POST.get('scope', self.scope)

--- a/velruse/providers/yandex.py
+++ b/velruse/providers/yandex.py
@@ -14,6 +14,7 @@ from ..api import (
     AuthenticationDenied,
     register_provider,
 )
+from ..events import with_events, AuthenticationStarted
 from ..exceptions import CSRFError, ThirdPartyFailure
 from ..settings import ProviderSettings
 from ..utils import flat_url
@@ -86,6 +87,7 @@ class YandexProvider(object):
         # consistency.
         self.callback_route = 'velruse.{name}-callback'.format(name=name)
 
+    @with_events(AuthenticationStarted)
     def login(self, request):
         """Initiate a Yandex login"""
         request.session['state'] = state = uuid.uuid4().hex


### PR DESCRIPTION
This pull request adds support for firing the AuthenticationStarted before redirecting the user to the provider authentication page.

The implementation uses a decorator, but this could be removed if velruse gains a base class for all the OAuth based providers.
