### PR TITLE
Fixed random empty 'utc_offset' requests

### DIFF
--- a/velruse/providers/twitter.py
+++ b/velruse/providers/twitter.py
@@ -154,7 +154,7 @@ class TwitterProvider(object):
                 profile['addresses'] = [{'formatted': data['location']}]
             if 'profile_image_url' in data:
                 profile['photos'] = [{'value': data['profile_image_url']}]
-            if 'utc_offset' in data:
+            if data.get('utc_offset'):
                 offset = float(data['utc_offset']) / 3600
                 h = int(offset)
                 m = int(abs(offset - h) * 60)


### PR DESCRIPTION
Sometimes twitter sends a null utc_offset as part of the twitter json response. So I've modified `if 'utc_offset' in data` to `if data.get('utc_offset')`. This seems to handle both cases. Added for issue #128
