### PR TITLE
Check for correct get params in linkedin callback

### DIFF
--- a/velruse/providers/linkedin.py
+++ b/velruse/providers/linkedin.py
@@ -95,8 +95,9 @@ class LinkedInProvider(object):
 
     def callback(self, request):
         """Process the LinkedIn redirect"""
-        if 'denied' in request.GET:
-            return AuthenticationDenied("User denied authentication",
+        if 'oauth_problem' in request.GET:
+            oauth_problems = ','.join(request.GET.getall('oauth_problem'))
+            return AuthenticationDenied("ProblemReporting: %s" % oauth_problems,
                                         provider_name=self.name,
                                         provider_type=self.type)
 


### PR DESCRIPTION
LinkedIn uses OAuth ProblemReporting extension (http://wiki.oauth.net/w/page/12238543/ProblemReporting) to report a problem to consumers. Checking for denied param will not throw AuthenticationDenied view if the user denies the authentication.
