### PR TITLE
Reddit provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py?
 *.egg-info
+*.egg
 *.swp
 *.vim
 config.yaml

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -20,3 +20,4 @@ as a part of the velruse standalone application.
    providers/vk
    providers/yahoo
    providers/yandex
+   providers/reddit

--- a/docs/providers/reddit.rst
+++ b/docs/providers/reddit.rst
@@ -1,0 +1,49 @@
+Reddit - :mod:`velruse.providers.reddit`
+========================================
+
+The Reddit provider combines authentication with OAuth 2.0 authorization.
+It requires a Reddit App to have been created to use.
+
+Reddit Links:
+
+* `Register a New Reddit Application
+  <https://ssl.reddit.com/prefs/apps/>`__
+* `Reddit OAuth 2.0 API <https://github.com/reddit/reddit/wiki/OAuth2>`__
+
+
+Settings
+--------
+
+``consumer_key``
+    reddit application consumer key
+``consumer_secret``
+    reddit application secret
+``scope``
+    reddit application scope - defaults to identity
+
+
+POST Parameters
+---------------
+
+Complete Example:
+
+.. code-block:: html
+
+    <form action="/velruse/reddit/login" method="post">
+        <input type="submit" value="Login with Reddit" />
+    </form>
+
+
+Pyramid API
+-----------
+
+.. automodule:: velruse.providers.reddit
+
+   .. autoclass:: RedditAuthenticationComplete
+      :show-inheritance:
+
+   .. autofunction:: includeme
+
+   .. autofunction:: add_reddit_login
+
+   .. autofunction:: add_reddit_login_from_settings

--- a/docs/providers/reddit.rst
+++ b/docs/providers/reddit.rst
@@ -9,6 +9,7 @@ Reddit Links:
 * `Register a New Reddit Application
   <https://ssl.reddit.com/prefs/apps/>`__
 * `Reddit OAuth 2.0 API <https://github.com/reddit/reddit/wiki/OAuth2>`__
+* `Reddit API Rules <https://github.com/reddit/reddit/wiki/API>`__
 
 
 Settings
@@ -19,7 +20,9 @@ Settings
 ``consumer_secret``
     reddit application secret
 ``scope``
-    reddit application scope - defaults to identity
+    scope - defaults to identity
+``user_agent``
+    User-Agent header requests should use: Reddit asks for a unique and descriptive user-agent string. (e.g. User-Agent: flairbot/1.0 by spladug)
 
 
 POST Parameters

--- a/example_test.ini
+++ b/example_test.ini
@@ -17,6 +17,7 @@ test_providers =
 #    openid
 #    twitter
 #    yahoo
+#    reddit
 
 bitbucket.app =
 bitbucket.login =
@@ -57,6 +58,9 @@ twitter.password =
 yahoo.login =
 yahoo.password =
 
+reddit.login =
+reddit.password =
+
 [app:main]
 use = call:tests.selenium.testapp:main
 
@@ -71,6 +75,7 @@ login_providers =
 #    openid
 #    twitter
 #    yahoo
+#    reddit
 
 # Bitbucket
 velruse.bitbucket.consumer_key =
@@ -117,3 +122,7 @@ velruse.twitter.consumer_secret =
 velruse.yahoo.realm =
 velruse.yahoo.consumer_key =
 velruse.yahoo.consumer_secret =
+
+# Reddit
+velruse.reddit.consumer_key =
+velruse.reddit.consumer_secret =

--- a/example_test.ini
+++ b/example_test.ini
@@ -126,3 +126,4 @@ velruse.yahoo.consumer_secret =
 # Reddit
 velruse.reddit.consumer_key =
 velruse.reddit.consumer_secret =
+velruse.reddit.user_agent =

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,11 @@ import sys
 
 from setuptools import setup, find_packages
 
-import velruse
-
 PY3 = sys.version_info[0] >= 3
 
 requires = [
     'pyramid',
+    'pyramid_mako',
     'requests',
     'requests-oauthlib',
     'anykeystore',
@@ -40,7 +39,7 @@ except IOError:
     README = CHANGES = ''
 
 setup(name='velruse',
-      version=velruse.__version__,
+      version='1.1.1',
       description=(
           'Simplifying third-party authentication for web applications.'),
       long_description=README + '\n\n' + CHANGES,

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import sys
 
 from setuptools import setup, find_packages
 
+import velruse
+
 PY3 = sys.version_info[0] >= 3
 
 requires = [
@@ -38,7 +40,7 @@ except IOError:
     README = CHANGES = ''
 
 setup(name='velruse',
-      version='1.1.1',
+      version=velruse.__version__,
       description=(
           'Simplifying third-party authentication for web applications.'),
       long_description=README + '\n\n' + CHANGES,

--- a/tests/selenium/testapp/__init__.py
+++ b/tests/selenium/testapp/__init__.py
@@ -48,13 +48,14 @@ def main(global_conf, **settings):
     session_factory = UnencryptedCookieSessionFactoryConfig('seekrit')
 
     providers = settings.get('login_providers', '')
-    providers = filter(None, [p.strip()
+    providers = list(filter(None, [p.strip()
                               for line in providers.splitlines()
-                              for p in line.split(', ')])
+                              for p in line.split(', ')]))
     settings['login_providers'] = providers
 
     config = Configurator(settings=settings)
     config.set_session_factory(session_factory)
+    config.include('pyramid_mako')
 
     if 'facebook' in providers:
         config.include('velruse.providers.facebook')
@@ -133,6 +134,13 @@ def main(global_conf, **settings):
         config.add_linkedin_login(
             settings['velruse.linkedin.consumer_key'],
             settings['velruse.linkedin.consumer_secret'],
+        )
+
+    if 'reddit' in providers:
+        config.include('velruse.providers.reddit')
+        config.add_reddit_login(
+            settings['velruse.reddit.consumer_key'],
+            settings['velruse.reddit.consumer_secret'],
         )
 
     config.scan(__name__)

--- a/tests/selenium/testapp/__init__.py
+++ b/tests/selenium/testapp/__init__.py
@@ -141,6 +141,7 @@ def main(global_conf, **settings):
         config.add_reddit_login(
             settings['velruse.reddit.consumer_key'],
             settings['velruse.reddit.consumer_secret'],
+            user_agent=settings['velruse.reddit.user_agent'],
         )
 
     config.scan(__name__)

--- a/tests/selenium/testapp/templates/login.mako
+++ b/tests/selenium/testapp/templates/login.mako
@@ -37,6 +37,7 @@ ${form('twitter', 'Login with Twitter')}
 ${form('yahoo', 'Login with Yahoo',
        oauth='true',
        openid_identifier='yahoo.com')}
+${form('reddit', 'Login with Reddit')}
 
 </body>
 </html>

--- a/velruse/__init__.py
+++ b/velruse/__init__.py
@@ -1,5 +1,3 @@
-__version__ = '1.1.1'
-
 class AuthenticationComplete(object):
     """ An AuthenticationComplete context object"""
 

--- a/velruse/__init__.py
+++ b/velruse/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '1.1.1'
+
 class AuthenticationComplete(object):
     """ An AuthenticationComplete context object"""
 

--- a/velruse/providers/reddit.py
+++ b/velruse/providers/reddit.py
@@ -1,0 +1,185 @@
+"""Reddit Authentication Views"""
+import uuid
+
+from pyramid.httpexceptions import HTTPFound
+from pyramid.security import NO_PERMISSION_REQUIRED
+
+import requests
+
+from ..api import (
+    AuthenticationComplete,
+    AuthenticationDenied,
+    register_provider,
+)
+from ..exceptions import CSRFError
+from ..exceptions import ThirdPartyFailure
+from ..settings import ProviderSettings
+from ..utils import flat_url
+
+
+class RedditAuthenticationComplete(AuthenticationComplete):
+    """Reddit auth complete"""
+
+
+def includeme(config):
+    config.add_directive('add_reddit_login', add_reddit_login)
+    config.add_directive('add_reddit_login_from_settings',
+                         add_reddit_login_from_settings)
+
+
+def add_reddit_login_from_settings(config, prefix='velruse.reddit.'):
+    settings = config.registry.settings
+    p = ProviderSettings(settings, prefix)
+    p.update('consumer_key', required=True)
+    p.update('consumer_secret', required=True)
+    p.update('scope')
+    p.update('login_path')
+    p.update('callback_path')
+    p.update('domain')
+    config.add_reddit_login(**p.kwargs)
+
+
+def add_reddit_login(config,
+                     consumer_key,
+                     consumer_secret,
+                     scope=None,
+                     login_path='/login/reddit',
+                     callback_path='/login/reddit/callback',
+                     domain='reddit.com',
+                     name='reddit'):
+    """
+    Add a Reddit login provider to the application.
+    """
+    provider = RedditProvider(name,
+                              consumer_key,
+                              consumer_secret,
+                              scope,
+                              domain)
+
+    config.add_route(provider.login_route, login_path)
+    config.add_view(provider, attr='login', route_name=provider.login_route,
+                    permission=NO_PERMISSION_REQUIRED)
+
+    config.add_route(provider.callback_route, callback_path,
+                     use_global_views=True,
+                     factory=provider.callback)
+
+    register_provider(config, name, provider)
+
+
+class RedditProvider(object):
+    def __init__(self,
+                 name,
+                 consumer_key,
+                 consumer_secret,
+                 scope,
+                 domain):
+        self.name = name
+        self.type = 'reddit'
+        self.consumer_key = consumer_key
+        self.consumer_secret = consumer_secret
+        self.scope = scope
+        self.protocol = 'https'
+        self.domain = domain
+
+        self.login_route = 'velruse.{name}-login'.format(name=name)
+        self.callback_route = 'velruse.{name}-callback'.format(name=name)
+
+    def login(self, request):
+        """Initiate a reddit login"""
+        scope = request.POST.get('scope', self.scope)
+        request.session['velruse.state'] = state = uuid.uuid4().hex
+        reddit_url = flat_url(
+            '{protocol}://ssl.{domain}/api/v1/authorize'.format(
+                protocol=self.protocol,
+                domain=self.domain
+            ),
+            scope=scope,
+            client_id=self.consumer_key,
+            redirect_uri=request.route_url(self.callback_route),
+            response_type='code',
+            duration='permanent',
+            state=state)
+        return HTTPFound(location=reddit_url)
+
+    def callback(self, request):
+        """Process the reddit redirect"""
+        sess_state = request.session.pop('velruse.state', None)
+        req_state = request.GET.get('state')
+        if not sess_state or sess_state != req_state:
+            raise CSRFError(
+                'CSRF Validation check failed. Request state {req_state} is '
+                'not the same as session state {sess_state}'.format(
+                    req_state=req_state,
+                    sess_state=sess_state
+                )
+            )
+        code = request.GET.get('code')
+        if not code:
+            reason = request.GET.get('error', 'No reason provided.')
+            return AuthenticationDenied(reason=reason,
+                                        provider_name=self.name,
+                                        provider_type=self.type)
+
+        # Now retrieve the access token with the code
+        access_url = '{protocol}://ssl.{domain}/api/v1/access_token'.format(
+            protocol=self.protocol,
+            domain=self.domain
+        )
+        post_data = dict(redirect_uri=request.route_url(self.callback_route),
+                         grant_type='authorization_code',
+                         code=code)
+        r = requests.post(access_url, data=post_data, auth=(self.consumer_key,
+                          self.consumer_secret))
+        if r.status_code != 200:
+            raise ThirdPartyFailure(
+                "Status {code}: {content}".format(
+                    code=r.status_code,
+                    content=r.content
+                )
+            )
+
+        token_data = r.json()
+        access_token = token_data['access_token']
+        headers = {
+            'Authorization': 'Bearer {token}'.format(token=access_token)
+        }
+        api_url = '{protocol}://oauth.{domain}/api/v1/'.format(
+            protocol=self.protocol,
+            domain=self.domain
+        )
+        api_method = 'me'
+        api_full_url = '{url}{method}'.format(
+            url=api_url,
+            method=api_method
+        )
+
+        # Retrieve profile data
+        r = requests.get(api_full_url, headers=headers)
+        if r.status_code != 200:
+            raise ThirdPartyFailure(
+                "Status {code}: {content}".format(
+                    code=r.status_code,
+                    content=r.content
+                )
+            )
+
+        profile_data = r.json()
+        import logging
+        LOG = logging.getLogger(__name__)
+        LOG.debug(profile_data)
+        profile = {}
+        profile['accounts'] = [{
+            'domain': self.domain,
+            'username': profile_data['name'],
+            'userid': profile_data['id']
+        }]
+
+        profile['preferredUsername'] = profile_data['name']
+        profile['displayName'] = profile_data['name']
+
+        cred = {'oauthAccessToken': access_token}
+        return RedditAuthenticationComplete(profile=profile,
+                                            credentials=cred,
+                                            provider_name=self.name,
+                                            provider_type=self.type)

--- a/velruse/providers/reddit.py
+++ b/velruse/providers/reddit.py
@@ -165,9 +165,6 @@ class RedditProvider(object):
             )
 
         profile_data = r.json()
-        import logging
-        LOG = logging.getLogger(__name__)
-        LOG.debug(profile_data)
         profile = {}
         profile['accounts'] = [{
             'domain': self.domain,

--- a/velruse/providers/reddit.py
+++ b/velruse/providers/reddit.py
@@ -48,7 +48,7 @@ def add_reddit_login(config,
                      callback_path='/login/reddit/callback',
                      domain='reddit.com',
                      name='reddit',
-                     user_agent='velruse/1.1.1'):
+                     user_agent='velruse'):
     """
     Add a Reddit login provider to the application.
     """

--- a/velruse/providers/reddit.py
+++ b/velruse/providers/reddit.py
@@ -42,7 +42,7 @@ def add_reddit_login_from_settings(config, prefix='velruse.reddit.'):
 def add_reddit_login(config,
                      consumer_key,
                      consumer_secret,
-                     scope=None,
+                     scope='identity',
                      login_path='/login/reddit',
                      callback_path='/login/reddit/callback',
                      domain='reddit.com',


### PR DESCRIPTION
Reddit takes its sweet time, on the order of tens of seconds, to respond. I'm not sure of the practical use of this but here it is.

Reddit asks in the rules to provide a descriptive user-agent. Generic user-agents like "python" (requests uses a generic user-agent) are severely rate limited. I added a config option for the end-user to provide an application/version specific user-agent. It defaults to "velruse" currently but it would be best if the Velruse version number was included. I didn't want to munge around with setup.py to be able to provide that information so I left it as "velruse".

I tested on 2.7 and 3.3.

Let me know if something is amiss. 
