### PR TITLE
Use updated live.com endpoints.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ except IOError:
     README = CHANGES = ''
 
 setup(name='velruse',
-      version='1.1.1',
+      version='1.1.1a',
       description=(
           'Simplifying third-party authentication for web applications.'),
       long_description=README + '\n\n' + CHANGES,

--- a/velruse/providers/live.py
+++ b/velruse/providers/live.py
@@ -94,14 +94,15 @@ class LiveProvider(object):
                                         provider_type=self.type)
 
         # Now retrieve the access token with the code
-        access_url = flat_url(
-            'https://login.live.com/oauth20_token.srf',
-            client_id=self.consumer_key,
-            client_secret=self.consumer_secret,
-            redirect_uri=request.route_url(self.callback_route),
-            grant_type="authorization_code",
-            code=code)
-        r = requests.get(access_url)
+        access_url = 'https://login.live.com/oauth20_token.srf'
+        access_data = {
+            "client_id": self.consumer_key,
+            "client_secret": self.consumer_secret,
+            "redirect_uri": request.route_url(self.callback_route),
+            "grant_type": "authorization_code",
+            "code": code
+        }
+        r = requests.post(access_url, data=access_data)
         if r.status_code != 200:
             raise ThirdPartyFailure("Status %s: %s" % (
                 r.status_code, r.content))

--- a/velruse/providers/live.py
+++ b/velruse/providers/live.py
@@ -75,7 +75,7 @@ class LiveProvider(object):
         """Initiate a Live login"""
         scope = request.POST.get('scope', self.scope or
                                  'wl.basic wl.emails wl.signin')
-        fb_url = flat_url('https://oauth.live.com/authorize', scope=scope,
+        fb_url = flat_url('https://login.live.com/oauth20_authorize.srf', scope=scope,
                           client_id=self.consumer_key,
                           redirect_uri=request.route_url(self.callback_route),
                           response_type="code")
@@ -95,7 +95,7 @@ class LiveProvider(object):
 
         # Now retrieve the access token with the code
         access_url = flat_url(
-            'https://oauth.live.com/token',
+            'https://login.live.com/oauth20_token.srf',
             client_id=self.consumer_key,
             client_secret=self.consumer_secret,
             redirect_uri=request.route_url(self.callback_route),


### PR DESCRIPTION
We've had a problems with the live.com provider intermittently failing. Today it started failing all the time returning the error message 'The HTTP request was forbidden with client authentication scheme "Anonymous"'.

According to http://social.msdn.microsoft.com/Forums/onedrive/en-US/577aa2de-9409-405a-835f-327e06965f52/oauth-service-down?forum=messengerconnect — which may not be the most authoritative source — there are new endpoints that should be used.

The patch simply uses these new endpoints and our problems went away.
