### PR TITLE
Support mobile/AJAX one-step authentication using a POST to the login callback.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ except IOError:
     README = CHANGES = ''
 
 setup(name='velruse',
-      version='1.1.1',
+      version='1.1.1.1',
       description=(
           'Simplifying third-party authentication for web applications.'),
       long_description=README + '\n\n' + CHANGES,


### PR DESCRIPTION
When mobile clients use the platform SDK to authenticate, they can just send a resulting one-time-use token to the server for the server to use for authentication.

See https://developers.google.com/+/mobile/android/sign-in

This change allows mobile clients to POST to /login/google/callback with that code for a Google login experience.

I decided after some thought that it is OK that the "state" feature is not used in this case because the callback_uri is set to "postmessage" and Google will verify that this was the case when the token was issued.  However, if this isn't the case an extra API might be needed for a mobile client to fetch a state and then submit it with the login request.
