### PR TITLE
Fixed bug undex Python3 in providers.openid

### DIFF
--- a/velruse/providers/openid.py
+++ b/velruse/providers/openid.py
@@ -384,8 +384,9 @@ def extract_openid_data(identifier, sreg_resp, ax_resp):
         ud['thumbnailUrl'] = thumbnail
 
     # Now strip out empty values
+    stripped_ud = {}
     for k, v in ud.items():
-        if not v or (isinstance(v, list) and not v[0]):
-            del ud[k]
+        if v and not(isinstance(v, list) and not v[0]):
+            stripped_ud[k] = v
 
-    return ud
+    return stripped_ud


### PR DESCRIPTION
Running this code under Python 3.4 raises RuntimeError: dictionary changed size during iteration. That is why this fix creates a stripped copy of dictionary and then returns it.
