### PR TITLE
Fix Live provider (use POST instead of GET to avoid stacktrace).

### DIFF
--- a/velruse/providers/live.py
+++ b/velruse/providers/live.py
@@ -94,14 +94,13 @@ class LiveProvider(object):
                                         provider_type=self.type)
 
         # Now retrieve the access token with the code
-        access_url = flat_url(
-            'https://oauth.live.com/token',
+        r = requests.post('https://oauth.live.com/token', dict(
             client_id=self.consumer_key,
             client_secret=self.consumer_secret,
             redirect_uri=request.route_url(self.callback_route),
             grant_type="authorization_code",
-            code=code)
-        r = requests.get(access_url)
+            code=code),
+        )
         if r.status_code != 200:
             raise ThirdPartyFailure("Status %s: %s" % (
                 r.status_code, r.content))


### PR DESCRIPTION
I was getting this stack trace when using Microsoft Live:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/pyramid_debugtoolbar/toolbar.py", line 215, in toolbar_tween
    response = _handler(request)
  File "/usr/local/lib/python3.5/site-packages/pyramid_debugtoolbar/panels/performance.py", line 57, in resource_timer_handler
    result = handler(request)
  File "/usr/local/lib/python3.5/site-packages/pyramid/tweens.py", line 51, in excview_tween
    request_iface=request_iface.combined
  File "/usr/local/lib/python3.5/site-packages/pyramid/view.py", line 547, in _call_view
    response = view_callable(context, request)
  File "/usr/local/lib/python3.5/site-packages/pyramid/viewderivers.py", line 512, in csrf_view
    return view(context, request)
  File "/usr/local/lib/python3.5/site-packages/pyramid/viewderivers.py", line 413, in viewresult_to_response
    result = view(context, request)
  File "/usr/local/lib/python3.5/site-packages/pyramid/tweens.py", line 22, in excview_tween
    response = handler(request)
  File "/usr/local/lib/python3.5/site-packages/pyramid_tm/__init__.py", line 101, in tm_tween
    reraise(*exc_info)
  File "/usr/local/lib/python3.5/site-packages/pyramid_tm/compat.py", line 15, in reraise
    raise value
  File "/usr/local/lib/python3.5/site-packages/pyramid_tm/__init__.py", line 83, in tm_tween
    response = handler(request)
  File "/usr/local/lib/python3.5/site-packages/pyramid/router.py", line 127, in handle_request
    root = root_factory(request)
  File "/usr/local/lib/python3.5/site-packages/velruse/providers/live.py", line 107, in callback
    r.status_code, r.content))
velruse.exceptions.ThirdPartyFailure: Status 400: b'{"error":"invalid_request","error_description":"The provided request must be sent using the HTTP \'POST\' method."}'
```

Changing that request to a `POST` fixed the issue.
