### PR TITLE
Updae Facebook provider because they now return JSON for the access_token

### DIFF
--- a/velruse/providers/facebook.py
+++ b/velruse/providers/facebook.py
@@ -118,7 +118,7 @@ class FacebookProvider(object):
         if r.status_code != 200:
             raise ThirdPartyFailure("Status %s: %s" % (
                 r.status_code, r.content))
-        access_token = dict(parse_qsl(r.text))['access_token']
+        access_token = r.json()['access_token']
 
         # Retrieve profile data
         graph_url = flat_url('https://graph.facebook.com/me',


### PR DESCRIPTION
From their changelog:

[Oauth Access Token] Format - The response format of https://www.facebook.com/v2.3/oauth/access_token returned when you exchange a code for an access_token now return valid JSON instead of being URL encoded. The new format of this response is {"access_token": {TOKEN}, "token_type":{TYPE}, "expires_in":{TIME}}. We made this update to be compliant with section 5.1 of RFC 6749.

Otherwise the Facebook provider is now broken since they stopped supporting the old way.