### PR TITLE
docs: Fix simple typo, identifer -> identifier

### DIFF
--- a/docs/providers/openid.rst
+++ b/docs/providers/openid.rst
@@ -38,7 +38,7 @@ POST Parameters
 ---------------
 
 The OpenID provider accepts `openid_identifier` which should designate
-the OpenID identifer being claimed to authenticate.
+the OpenID identifier being claimed to authenticate.
 
 Complete Example:
 


### PR DESCRIPTION
There is a small typo in docs/providers/openid.rst.

Should read `identifier` rather than `identifer`.

